### PR TITLE
Add host prefix to packages list view

### DIFF
--- a/cnrclient/commands/list_package.py
+++ b/cnrclient/commands/list_package.py
@@ -44,4 +44,4 @@ class ListPackageCmd(CommandBase):
         return self.result
 
     def _render_console(self):
-        return print_packages(self.result)
+        return print_packages(self.result, registry_host=self.registry_host)

--- a/cnrclient/display.py
+++ b/cnrclient/display.py
@@ -3,13 +3,13 @@ from tabulate import tabulate
 from cnrclient.utils import get_media_type
 
 
-def print_packages(packages):
+def print_packages(packages, registry_host=""):
     header = ['app', 'release', 'downloads', 'manifests']
     table = []
     for package in packages:
         release = package["default"]
         manifests = ", ".join(package['manifests'])
-        table.append([package['name'], release, str(package.get('downloads', '-')), manifests])
+        table.append([registry_host + "/" + package['name'], release, str(package.get('downloads', '-')), manifests])
     return tabulate(table, header)
 
 


### PR DESCRIPTION
```
$ helm registry list staging.quay.io
app                                            release    downloads    manifests
---------------------------------------------  ---------  -----------  -----------
staging.quay.io/jzelinskie/nginx               0.1.0      -            helm
staging.quay.io/charts/kube-lego               0.1.8      -            helm
```

```
$ helm registry list quay.io
app                                            release    downloads    manifests
---------------------------------------------  ---------  -----------  -----------
quay.io/jzelinskie/nginx               0.1.0      -            helm
quay.io/charts/kube-lego               0.1.8      -            helm
```