### PR TITLE
Windows build in Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,58 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+
+    # - PYTHON: "C:\\Python27"
+    # - PYTHON: "C:\\Python33"
+    # - PYTHON: "C:\\Python34"
+    # - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python27-x64"
+      BIN_NAME: cnr-%APPVEYOR_REPO_TAG_NAME%-win-x64
+    # - PYTHON: "C:\\Python33-x64"
+    # - PYTHON: "C:\\Python34-x64"
+    # - PYTHON: "C:\\Python35-x64"
+
+install:
+
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python --version"
+
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+
+  # We need wheel installed to build wheels
+  - "pip install -r requirements_tests.txt"
+  - "pip install -U pyinstaller"
+  - "pip install -e ."
+
+build: off
+
+test_script:
+  # Run the project tests
+  - "py.test --cov=cnrclient --cov-report=html --cov-report=term-missing  --verbose tests"
+
+after_test:
+  # If tests are successful, create binary packages for the project.
+  - "pyinstaller --onefile bin/cnr"
+  - ps: "ls dist"
+  - "copy dist\\cnr.exe %BIN_NAME%.exe"
+  - "mkdir registry"
+  - "copy dist\\cnr.exe registry\\cnr.exe"
+  - "copy cnrclient\\commands\\plugins\\helm\\cnr.sh registry\\cnr.sh"
+  - "copy cnrclient\\commands\\plugins\\helm\\plugin.yaml registry\\plugin.yaml"
+  - "7z a registry-%BIN_NAME%-helm-plugin.zip registry\\*.*"
+  - ps: "ls dist"
+  - ps: "ls registry"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: "%BIN_NAME%.exe"
+  - path: registry-%BIN_NAME%-helm-plugin.zip
+    type: zip
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ mkdir -p ~/.helm/plugins/
 tar xzvf registry-cnr-v0.3.7-dev-linux-x64-helm-plugin.tar.gz  -C ~/.helm/plugins/
 ```
 
+### Windows
+
+```
+wget https://github.com/cn-app-registry/cnr-cli/releases/download/v0.3.7-dev/registry-cnr-v0.3.7-dev-win-x64-helm-plugin.tar.gz
+mkdir -p ~/.helm/plugins/
+tar xzvf registry-cnr-v0.3.7-dev-linux-x64-helm-plugin.tar.gz  -C ~/.helm/plugins/
+```
+
+Note: You must have bash in your path and change the `registry/plugin.yaml` execution to call `bash -c $HELM_PLUGIN_DIR/cnr.sh`
+
+
 ## Deploy Jenkins Using Helm from the Quay Registry
 
 


### PR DESCRIPTION
This PR intent to add support for Windows build.
The appveyor file is complete and tested see https://ci.appveyor.com/project/rodcloutier/appr-cli/build/1.0.34).

We would need to setup an account for the app-registry user and create a build for tags only, add the script to release the build artifact.

I would be available to help setup the Appveyor automation.